### PR TITLE
Removed Households

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -6,7 +6,6 @@ project:
         namespace: refugee01
         api_version: '50.0'
     dependencies:
-        - github: 'https://github.com/SalesforceFoundation/Households'
         - github: 'https://github.com/SalesforceFoundation/PMM'
     git:
         default_branch: ''


### PR DESCRIPTION
# Critical Changes

# Changes
Removed 'Households' dependency from the CumulusCI.yml file, ran a build, and no errors.  As there are currently not actual dependencies in the metadata we should be able to safely remove this from the file and continue developing without any explicit dependencies on NPSP-related components.

# Issues Closed
